### PR TITLE
add TimedRotatingFileHandler to imports in case file-based logging is chosen

### DIFF
--- a/gdrivefs/log_config.py
+++ b/gdrivefs/log_config.py
@@ -1,5 +1,5 @@
 from logging import getLogger, Formatter, DEBUG, WARNING
-from logging.handlers import SysLogHandler
+from logging.handlers import SysLogHandler, TimedRotatingFileHandler
 from os.path import exists
 from sys import platform
 


### PR DESCRIPTION
Trivial change to make the recent update to log_config.py work with file logging.
