### PR TITLE
Fix statfs to return individual total/used/free values to df(1).

### DIFF
--- a/gdrivefs/gdfs/gdfuse.py
+++ b/gdrivefs/gdfs/gdfuse.py
@@ -562,13 +562,13 @@ class GDriveFS(LoggingMixIn,Operations):
             'f_bsize': block_size,
 
             # Total data blocks in file system.
-            'f_blocks': used,
+            'f_blocks': total,
 
             # Fragment size.
-#            'f_frsize': block_size,
+            'f_frsize': block_size,
 
             # Free blocks in filesystem.
-#            'f_bfree': free,
+            'f_bfree': free,
 
             # Free blocks avail to non-superuser.
             'f_bavail': free


### PR DESCRIPTION
Before this change, df(1) always reports total == used, even though the %free is calculated correctly.

If f_bfree is filled in, then df provides a correct triple of (total, used, free).

While here, go ahead and fill in f_frsize (since there's not really such a thing in gdrive, it can be == block_size).
