### PR TITLE
Don't pass _netdev option to fuse

### DIFF
--- a/gdrivefs/gdfs/gdfuse.py
+++ b/gdrivefs/gdfs/gdfuse.py
@@ -835,6 +835,9 @@ def mount(auth_storage_filepath, mountpoint, debug=None, nothreads=None,
                           in option_string.split(',') ]:
             k = opt_parts[0]
 
+            if k == "_netdev":
+                continue
+
             # We need to present a bool type for on/off flags. Since all we
             # have are strings, we'll convert anything with a 'True' or 'False'
             # to a bool, or anything with just a key to True.


### PR DESCRIPTION
Hi,

I've made gdrivefs to not pass _netdev option to fuse. The option is used for network file systems to prevent the system to mount the device on boot before configuring the network. The problem is that fuse throws an error on it.

Balous.