### PR TITLE
google-api-python-client moved to Github

### DIFF
--- a/gdrivefs/resources/README.rst
+++ b/gdrivefs/resources/README.rst
@@ -42,9 +42,9 @@ old version of their libraries, prior to when they fixed some Unicode problems
 that might cause failure when dealing with downloads/uploads of certain types
 of files.
 
-To install using *Mercurial*, do the following::
+To install using *Git*, do the following::
 
-    $ hg clone https://code.google.com/p/google-api-python-client
+    $ git clone https://github.com/google/google-api-python-client
 
     $ cd google-api-python-client
     $ sudo python setup.py install


### PR DESCRIPTION
Google Code has been archived, the code.google.com repository has not been updated for quite a while