### PR TITLE
Fix broken displaceables

### DIFF
--- a/gdrivefs/gdfs/displaced_file.py
+++ b/gdrivefs/gdfs/displaced_file.py
@@ -22,7 +22,7 @@ class DisplacedFile(object):
                "DisplacedFile can not wrap a non-NormalEntry object."
 
         self.__normalized_entry = normalized_entry
-        self.__filepath = tempfile.NamedTemporaryFile(delete=False)
+        self.__filepath = tempfile.NamedTemporaryFile(delete=False).name
 
     def __del__(self):
         os.unlink(self.__filepath)

--- a/gdrivefs/gdfs/displaced_file.py
+++ b/gdrivefs/gdfs/displaced_file.py
@@ -24,8 +24,9 @@ class DisplacedFile(object):
         self.__normalized_entry = normalized_entry
         self.__filepath = tempfile.NamedTemporaryFile(delete=False).name
 
-    def __del__(self):
-        os.unlink(self.__filepath)
+# TODO: find a good place to delete this file
+#    def __del__(self):
+#        os.unlink(self.__filepath)
 
     def deposit_file(self, mime_type):
         """Write the file to a temporary path, and present a stub (JSON) to the 

--- a/gdrivefs/gdfs/fsutility.py
+++ b/gdrivefs/gdfs/fsutility.py
@@ -91,7 +91,7 @@ def dec_hint(argument_names=[], excluded=[], prefix='', otherdata_cb=None):
 def strip_export_type(path):
 
     matched = re.search(
-                r'#([a-zA-Z0-9\-]+\\+[a-zA-Z0-9\-]+)?$', 
+                r'#([a-zA-Z0-9\-]+\+[a-zA-Z0-9\-]+)?$',
                 path.encode('utf-8'))
 
     mime_type = None


### PR DESCRIPTION
Displaceables seem to be broken, and also seem to have been that way for some time

The first problem was introduced recently in commit daa1c3844d711c1331872896e9a531bf546af7e2 (using `r''` syntax turns `\\` into two backslashes instead of just one)

The second one seems to be present for a long time (probably d6b20b77d3b5652e95516fbc99d2eb60786101e7) and is caused by assigning a `NamedTemporaryFile` file object where a file name was expected. Also, the created temporary file seemed to be removed before I even had a chance to read it

With that being said, I don't really like the concept of displaceables as it requires the user to manually put the complete mime-type and navigate to the corresponding temporary file.

I think a better solution to this would be to expose virtual files with the correct extension for the corresponding exportable mime-types.

For instance, if we have a Google Docs document named "Hello World", we could simply provide the different exportable formats as multiple file entries :

```
Hello World.pdf
Hello World.docx
Hello World.rtf
```

The list of allowable extensions that appear in the listing by default would be configurable (not everyone needs .rtf !) and it would still be possible to ask for a specific extension even if it's unlisted.

I have not researched the possible performance issues with this idea, I suppose this could slow down directory listings if fetching each of the exported versions is required in order to expose the correct file size. Perhaps this could be dealt with by using some workaround (by exposing the files as symlinks for instance).
