### PR TITLE
Support for Unicode pathnames and user-mount convenience

### DIFF
--- a/gdrivefs/gdfs/gdfuse.py
+++ b/gdrivefs/gdfs/gdfuse.py
@@ -852,6 +852,10 @@ def mount(auth_storage_filepath, mountpoint, debug=None, nothreads=None,
             else:
                 v = True
 
+            # ignore the "user" option so we can put in fstab easily
+            if k == "user":
+                continue
+
             # We have a list of provided options. See which match against our 
             # application options.
 

--- a/gdrivefs/gdfs/opened_file.py
+++ b/gdrivefs/gdfs/opened_file.py
@@ -197,7 +197,7 @@ class OpenedFile(object):
         self.__is_loaded = False
         self.__is_dirty = False
 
-        temp_filename = self.__entry_id.encode('ASCII')
+        temp_filename = self.__entry_id.encode('utf8')
         om = get_om()
         self.__temp_filepath = os.path.join(om.temp_path, temp_filename)
 

--- a/gdrivefs/gdtool/normal_entry.py
+++ b/gdrivefs/gdtool/normal_entry.py
@@ -213,7 +213,7 @@ class NormalEntry(object):
             return data
 
     def get_data(self):
-            original = dict([(key.encode('ASCII'), value) 
+            original = dict([(key.encode('utf8'), value)
                                 for key, value 
                                 in self.__raw_data.iteritems()])
 


### PR DESCRIPTION
Hi,

I'd like to suggest these 2 commits, to support unicode pathnames, and to help with fstab installs, by letting a non-root user mount an fstab-configured Google Drive filesystem.

Hope you'll consider these.

Thanks,
