### PR TITLE
Fix I/O error when creating empty file

### DIFF
--- a/gdrivefs/gdtool/drive.py
+++ b/gdrivefs/gdtool/drive.py
@@ -458,13 +458,16 @@ class _GdriveManager(object):
                 _logger.debug("Read chunk: STATUS=[%s] DONE=[%s] "
                               "TOTAL_SIZE=[%s]", status, done, total_size)
 
-                p = status.progress()
+                if status.total_size > 0:
+                    percent = status.progress()
+                else:
+                    percent = 100.0
 
                 _logger.debug("Chunk: PROGRESS=[%s] TOTAL-SIZE=[%s] "
                               "RESUMABLE-PROGRESS=[%s]",
-                              p, status.total_size, status.resumable_progress)
+                              percent, status.total_size,
+                              status.resumable_progress)
 
-                percent = p if status.total_size > 0 else 100.0
 # TODO(dustin): This just places an arbitrary limit on the number of empty 
 #               chunks we can receive. Can we drop this to 1?
                 if len(progresses) >= _MAX_EMPTY_CHUNKS:


### PR DESCRIPTION
~~`httplib 0.9.2` raises an exception when determining the progress of a zero-length transaction, which causes an I/O error.~~ This skips the check entirely, since the result isn't used anyway when the `total_size` is zero.

I don't know how many people are affected by this, but obviously most files are empty when created. (Is it possible to create a nonempty file in one operation?)

Anyway, with this patch `GDriveFS` seems quite usable!
