### PR TITLE
gdtool/chunked_download: fix broken import

### DIFF
--- a/gdrivefs/gdtool/chunked_download.py
+++ b/gdrivefs/gdtool/chunked_download.py
@@ -2,7 +2,10 @@ import logging
 import time
 import random
 
-import oauth2client
+try:
+  from oauth2client import util
+except ImportError:
+  from oauth2client import _helpers as util
 import apiclient.http
 import apiclient.errors
 
@@ -19,7 +22,7 @@ class ChunkedDownload(object):
     that needs to be downloaded (not a request object, which doesn't apply here).
     """
 
-    @oauth2client.util.positional(4)
+    @util.positional(4)
     def __init__(self, fd, http, uri, chunksize=DEFAULT_CHUNK_SIZE, start_at=0):
         """Constructor.
 
@@ -43,7 +46,7 @@ class ChunkedDownload(object):
         self._sleep = time.sleep
         self._rand = random.random
 
-    @oauth2client.util.positional(1)
+    @util.positional(1)
     def next_chunk(self, num_retries=0):
         """Get the next chunk of the download.
 


### PR DESCRIPTION
After oauth2client commit 2f5c53b1fa ("Merge util.py and _helpers.py")
the functionality provided by util is in _helpers.

This fixes the import to work with both newer and older versions of
oauth2client, until the older version gets deprecated.

Signed-off-by: Ioan-Adrian Ratiu <adi@adirat.com>