### PR TITLE
Update requirements.txt

### DIFF
--- a/gdrivefs/resources/requirements.txt
+++ b/gdrivefs/resources/requirements.txt
@@ -1,9 +1,9 @@
-fusepy==2.0.2
+fusepy>=2.0.2
 gevent==1.0
 gipc==0.4.0
-google-api-python-client==1.2
+google-api-python-client>=1.2
 greenlet==0.4.2
 httplib2==0.8
 python-dateutil==2.2
-six==1.7.3
+six>=1.7.3
 


### PR DESCRIPTION
Trying to install gdrivefs with pip breaks other packages that require six>=1.7.3

The requirements.txt is too restrictive. I've successfully installed gdrivefs and ran it with six==1.11.0, fusepy==2.0.4, and google-api-python-client==1.6.4.

Current workaround is to install gdrivefs and then update six afterwards.

While we're at it, perhaps the rest of the restrictions can be changed to >=? the newest version of httplib2 also works.

Cheers!