### PR TITLE
Ignore system mount options

### DIFF
--- a/gdrivefs/gdfuse.py
+++ b/gdrivefs/gdfuse.py
@@ -9,7 +9,7 @@ import resource
 import pprint
 import math
 
-from errno import ENOENT, EIO, ENOTDIR, ENOTEMPTY, EPERM, EEXIST
+from errno import ENOENT, EIO, EISDIR, ENOTDIR, ENOTEMPTY, EPERM, EEXIST
 from fuse import FUSE, Operations, FuseOSError, c_statvfs, fuse_get_context, \
                  LoggingMixIn
 from time import mktime, time
@@ -697,7 +697,7 @@ class _GdfsMixin(object):
             _logger.error("Can not unlink() directory [%s] with ID [%s]. "
                           "Must be file.", file_path, entry_id)
 
-            raise FuseOSError(errno.EISDIR)
+            raise FuseOSError(EISDIR)
 
         # Remove online. Complements local removal (if not found locally, a 
         # follow-up request checks online).

--- a/gdrivefs/gdfuse.py
+++ b/gdrivefs/gdfuse.py
@@ -839,7 +839,8 @@ def mount(auth_storage_filepath, mountpoint, debug=None, nothreads=None,
                 _logger.debug("Forwarding option [%s] with value [%s] to "
                               "FUSE.", k, v)
 
-                fuse_opts[k] = v
+                if k not in ('user', '_netdev'):
+                    fuse_opts[k] = v
 
     if gdrivefs.config.IS_DEBUG is True:
         _logger.debug("FUSE options:\n%s", pprint.pformat(fuse_opts))


### PR DESCRIPTION
Problems:
1. To allow user be able to mount their Google Drive by themselves, fstab must have `user` option. This PR shoudl fix #136.
2. To auto mount Google Drive, it should wait for network service first, so I add to ignore `_netdev` option too. This also duplicate PR #125 but without conflict with the current code.