### PR TITLE
Dealing with Multi threading issue:  https://github.com/dsoprea/GDriveFS/issues/132

### DIFF
--- a/gdrivefs/config/__init__.py
+++ b/gdrivefs/config/__init__.py
@@ -1,5 +1,6 @@
 import os
 
 IS_DEBUG = bool(int(os.environ.get('GD_DEBUG', '0')))
+NO_THREADS = bool(int(os.environ.get('GD_NOTHREADS', '1')))
 DO_LOG_FUSE_MESSAGES = bool(int(os.environ.get('GD_DO_LOG_FUSE_MESSAGES', '0')))
 DEFAULT_CREDENTIALS_FILEPATH = os.path.expandvars('$HOME/.gdfs/creds')

--- a/gdrivefs/resources/README.rst
+++ b/gdrivefs/resources/README.rst
@@ -224,6 +224,20 @@ Just set the `GD_DEBUG` environment variable to "1"::
        flags=0x00000011
 
 
+Multi-threading FUSE
+====================
+
+It used to be that GDFS mounting used FUSE with no threads, only when running in
+debugging-mode, and actually if not in debugging-mode, FUSE was always used
+with threads.
+
+Currently, using FUSE with threads corrupts data reads, once mounted.  Then now
+multi-threading is decoupled from debugging-mode, and by default set to no threads.
+
+To enable threads back when mounting GDFS, just set the `GD_NOTHREADS` environment
+variable to "0" (1 by default).
+
+
 Troubleshooting Steps
 =====================
 

--- a/gdrivefs/resources/scripts/gdfs
+++ b/gdrivefs/resources/scripts/gdfs
@@ -55,7 +55,7 @@ def _main():
         auth_storage_filepath=auth_storage_filepath,
         mountpoint=args.mountpoint,
         debug=gdrivefs.config.IS_DEBUG,
-        nothreads=gdrivefs.config.IS_DEBUG,
+        nothreads=gdrivefs.config.NO_THREADS,
         option_string=option_string)
 
 if __name__ == '__main__':

--- a/gdrivefs/resources/scripts/gdfstool
+++ b/gdrivefs/resources/scripts/gdfstool
@@ -74,7 +74,7 @@ def _handle_mountpoint(args):
         auth_storage_filepath=args.auth_storage_file,
         mountpoint=args.mountpoint,
         debug=gdrivefs.config.IS_DEBUG,
-        nothreads=gdrivefs.config.IS_DEBUG,
+        nothreads=gdrivefs.config.NO_THREADS,
         option_string=option_string)
 
 def _parser_auth(subparsers):


### PR DESCRIPTION
So it happens that with fuse multi threading enabled, reading files breaks, to the point that a simple diff between directories fail a bunch of files if not all.  It also gives quite a few weird errors.

This PR attempts to decouple threading from debugging, which in the original code are mixed and hard coded, leaving the option to the user to turn on/off multi threading, and having it disabled by default (the safe way).