### PR TITLE
Fix I/O error due to HTTP 416 when downloading empty files

### DIFF
--- a/gdrivefs/chunked_download.py
+++ b/gdrivefs/chunked_download.py
@@ -148,5 +148,16 @@ class ChunkedDownload(object):
                         self._total_size), \
                     self._done, \
                     self._total_size)
+
+        elif resp.status == 416:
+            if self._total_size is None:
+                self._total_size = 0
+
+            self._done = self._progress == self._total_size
+
+            return (apiclient.http.MediaDownloadProgress(
+                        self._progress, self._total_size),
+                    self._done, self._total_size)
+
         else:
             raise apiclient.errors.HttpError(resp, content, uri=self._uri)


### PR DESCRIPTION
Hi!

Today I started getting I/O errors when trying to read from or write to empty files using GDriveFS.

After some debugging I found out that it's getting HTTP 416 status (Request range not satisfiable) from the Google Drive servers when trying to download a file. I'm not sure if something has changed on the Google side, or why it worked before, but I think it does make sense to reply with 416 if the server can't return even a single byte from the requested range.

So I made this fix to treat 416 status as an empty file.